### PR TITLE
fix: Markdown field rendering in form

### DIFF
--- a/app/Livewire/EventRegistration.php
+++ b/app/Livewire/EventRegistration.php
@@ -10,7 +10,6 @@ use App\Models\Registration;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
@@ -25,7 +24,6 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 /**
@@ -206,9 +204,10 @@ class EventRegistration extends SimplePage
                 FormFieldType::Select => Select::make("entries.{$entryKey}.{$field->name}")
                     ->label($field->name)
                     ->options(array_combine($field->options ?? [], $field->options ?? [])),
-                FormFieldType::Description => Placeholder::make("description_{$entryKey}_{$field->id}")
+                FormFieldType::Description => TextEntry::make("description_{$entryKey}_{$field->id}")
                     ->hiddenLabel()
-                    ->content(new HtmlString($field->content ?? ''))
+                    ->state($field->content ?? '')
+                    ->markdown()
                     ->columnSpanFull(),
             };
 


### PR DESCRIPTION
Markdown wurde nicht richtig im `Palceholder` Feld angezeigt.